### PR TITLE
Integrate multi-layer Q-Former between ViT and GPT-2

### DIFF
--- a/q_former.py
+++ b/q_former.py
@@ -1,0 +1,62 @@
+import torch
+import torch.nn as nn
+
+class QFormerLayer(nn.Module):
+    """A single Q-Former layer with self-attention, cross-attention and FFN."""
+    def __init__(self, hidden_size: int, num_heads: int):
+        super().__init__()
+        self.self_attn = nn.MultiheadAttention(hidden_size, num_heads, batch_first=True)
+        self.norm1 = nn.LayerNorm(hidden_size)
+
+        self.cross_attn = nn.MultiheadAttention(hidden_size, num_heads, batch_first=True)
+        self.norm2 = nn.LayerNorm(hidden_size)
+
+        self.ffn = nn.Sequential(
+            nn.Linear(hidden_size, hidden_size * 4),
+            nn.GELU(),
+            nn.Linear(hidden_size * 4, hidden_size),
+        )
+        self.norm3 = nn.LayerNorm(hidden_size)
+
+    def forward(self, query: torch.Tensor, key_value: torch.Tensor) -> torch.Tensor:
+        """Forward pass for a single layer.
+
+        Args:
+            query: Query tokens of shape (B, Q, C).
+            key_value: Visual features to attend to, shape (B, N, C).
+        Returns:
+            Updated query tokens of shape (B, Q, C).
+        """
+        q = query + self.self_attn(query, query, query)[0]
+        q = self.norm1(q)
+
+        q = q + self.cross_attn(q, key_value, key_value)[0]
+        q = self.norm2(q)
+
+        q = q + self.ffn(q)
+        q = self.norm3(q)
+        return q
+
+
+class QFormer(nn.Module):
+    """Stack of Q-Former layers operating on learned query tokens."""
+    def __init__(self, num_queries: int, hidden_size: int, num_layers: int, num_heads: int):
+        super().__init__()
+        self.query_tokens = nn.Parameter(torch.randn(1, num_queries, hidden_size))
+        self.layers = nn.ModuleList([
+            QFormerLayer(hidden_size, num_heads) for _ in range(num_layers)
+        ])
+
+    def forward(self, image_embeds: torch.Tensor) -> torch.Tensor:
+        """Generate query embeddings conditioned on visual features.
+
+        Args:
+            image_embeds: Visual embeddings of shape (B, N, C).
+        Returns:
+            Query embeddings of shape (B, num_queries, C).
+        """
+        batch_size = image_embeds.size(0)
+        query_tokens = self.query_tokens.expand(batch_size, -1, -1)
+        for layer in self.layers:
+            query_tokens = layer(query_tokens, image_embeds)
+        return query_tokens

--- a/vit_gpt2_training_v3_vizwiz.py
+++ b/vit_gpt2_training_v3_vizwiz.py
@@ -1,3 +1,4 @@
+
 import torch
 
 from transformers import GPT2LMHeadModel, GPT2Tokenizer, GPT2Config
@@ -17,6 +18,8 @@ from pycocoevalcap.eval import COCOEvalCap
 from torch.optim import AdamW
 
 import re
+
+from q_former import QFormer
 
 torch.manual_seed(3)
 torch.cuda.manual_seed(3)
@@ -50,24 +53,40 @@ config = GPT2Config.from_pretrained('gpt2', add_cross_attention=True)
 gpt2_model = GPT2LMHeadModel.from_pretrained('gpt2', config=config)
 gpt2_model = gpt2_model.to(DEVICE)
 
-optimizer = AdamW(gpt2_model.parameters(), lr=5e-5)
+# Q-Former setup
+qformer = QFormer(
+    num_queries=32,
+    hidden_size=gpt2_model.config.hidden_size,
+    num_layers=6,
+    num_heads=gpt2_model.config.n_head,
+).to(DEVICE)
+
+optimizer = AdamW(list(gpt2_model.parameters()) + list(qformer.parameters()), lr=5e-5)
 
 writer = SummaryWriter(comment=f"______|vit|gpt_2|{dt.name}|")
 
-
 criterion = torch.nn.CrossEntropyLoss(ignore_index=gpt2_tokenizer.pad_token_id)
 
-def train_epoch(model, optimizer):
+def train_epoch(model, qformer, optimizer):
     model.train()
+    qformer.train()
     losses = 0
 
     for i, (image_feature, input_ids, attention_mask) in tqdm(enumerate(train_loader)):
-        
         image_feature = image_feature.to(DEVICE)
         attention_mask = attention_mask.to(DEVICE)
         input_ids = input_ids.to(DEVICE)
 
-        outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=input_ids, encoder_hidden_states=image_feature)
+        if image_feature.dim() == 2:
+            image_feature = image_feature.unsqueeze(1)
+        image_feature = qformer(image_feature)
+
+        outputs = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            labels=input_ids,
+            encoder_hidden_states=image_feature,
+        )
         loss = outputs.loss
         loss.backward()
         optimizer.step()
@@ -76,16 +95,18 @@ def train_epoch(model, optimizer):
     epoch_loss = losses / (i + 1)
     return epoch_loss
 
-
 def clean_caption_regex(caption, bos_token=gpt2_tokenizer.bos_token, eos_token=gpt2_tokenizer.eos_token, pad_token=gpt2_tokenizer.pad_token):
     pattern = f"({bos_token}|{eos_token}|{pad_token})"
     clean = re.sub(pattern, '', caption)
     clean = clean.strip()
     return clean
 
-def generate_captions(model, src):
+def generate_captions(model, qformer, src):
     max_len = 30
     batch_size = src.shape[0]
+    if src.dim() == 2:
+        src = src.unsqueeze(1)
+    src = qformer(src)
     encoding = gpt2_tokenizer([BOS_TOKEN] * batch_size, return_tensors='pt')
     generated = encoding["input_ids"].to(DEVICE)
     attention_mask = encoding["attention_mask"].to(DEVICE)
@@ -95,41 +116,36 @@ def generate_captions(model, src):
         next_token_logits = predictions[:, -1, :]
         next_token = torch.argmax(next_token_logits, dim=-1).unsqueeze(-1)
         generated = torch.cat((generated, next_token), dim=1)
-        # Update the attention mask to include the new token
         new_attention_mask = torch.ones((batch_size, 1), dtype=torch.long, device=generated.device)
         attention_mask = torch.cat((attention_mask, new_attention_mask), dim=1)
     generated_texts = [gpt2_tokenizer.decode(g, skip_special_tokens=True) for g in generated]
     return generated_texts
 
-
-    
-
-def test_epoch(model, best_score, epoch):
+def test_epoch(model, qformer, best_score, epoch):
     model.eval()
+    qformer.eval()
     data = []
     with torch.no_grad():
-        for i, (src, ids) in tqdm(enumerate(val_loader)):  
+        for i, (src, ids) in tqdm(enumerate(val_loader)):
             src = src.to(DEVICE)
-
-            
-            captions = generate_captions(model, src)
-
+            if src.dim() == 2:
+                src = src.unsqueeze(1)
+            captions = generate_captions(model, qformer, src)
             for caption, id in zip(captions, ids):
                 data.append({
                     "image_id": id.item(),
                     "caption" : caption[4:]
                 })
-    
+
     json_file = f"results/{dt.name}_result.json"
     with open(json_file, "w") as file:
         json.dump(data, file)
-    
+
     coco_result = coco.loadRes(json_file)
     coco_eval = COCOEvalCap(coco, coco_result)
     coco_eval.params['image_id'] = coco_result.getImgIds()
     coco_eval.evaluate()
 
-    # print output evaluation scores
     for metric, score in coco_eval.eval.items():
         print(f'{metric}: {score:.3f}')
         writer.add_scalar(f'{metric} Val Score', score, epoch)
@@ -139,17 +155,17 @@ def test_epoch(model, best_score, epoch):
                 json_file = f"results/best_{dt.name}_result.json"
                 with open(json_file, "w") as file:
                     json.dump(data, file)
-    
+
     return best_score
 from timeit import default_timer as timer
 NUM_EPOCHS = 150
 BEST_CIDER_SCORE = 0.0
 for epoch in range(1, NUM_EPOCHS+1):
     start_time = timer()
-    train_loss = train_epoch(gpt2_model, optimizer)
+    train_loss = train_epoch(gpt2_model, qformer, optimizer)
     writer.add_scalar(f'Train loss', train_loss, epoch)
     end_time = timer()
-    BEST_CIDER_SCORE = test_epoch(gpt2_model, BEST_CIDER_SCORE, epoch)
+    BEST_CIDER_SCORE = test_epoch(gpt2_model, qformer, BEST_CIDER_SCORE, epoch)
     print((f"Epoch: {epoch}, Train loss: {train_loss:.3f}, "f"Epoch time = {(end_time - start_time):.3f}s"))
     with open('best_cider_score.txt', 'w') as file:
         file.write(f"Best CIDEr Score: {BEST_CIDER_SCORE}")


### PR DESCRIPTION
## Summary
- add transformer-based Q-Former with self- and cross-attention
- route visual features through Q-Former before GPT-2 in MSCoco and VizWiz training scripts

## Testing
- `pytest`
- `python -m py_compile q_former.py vit_gpt2_training_v3_mscoco.py vit_gpt2_training_v3_vizwiz.py`


------
https://chatgpt.com/codex/tasks/task_e_689ecdb757508327b124f1b4c03d75a1