### PR TITLE
Add utility class for multi-GPU support

### DIFF
--- a/gpu_utils.py
+++ b/gpu_utils.py
@@ -1,0 +1,74 @@
+"""Utility for leveraging all available CUDA GPUs in PyTorch models.
+
+This module exposes :class:`CudaMultiGPU`, a lightweight wrapper that detects
+all CUDA devices on the host and moves a model to run on them in parallel via
+``torch.nn.DataParallel``.  It can be imported and used in any project without
+modification.
+
+Example
+-------
+Wrap a model so that it automatically utilizes every available GPU:
+
+>>> from gpu_utils import CudaMultiGPU
+>>> model = MyModel()
+>>> mgpu = CudaMultiGPU(model)
+>>> output = mgpu(input_tensor)  # ``mgpu`` is callable
+
+Alternatively access the wrapped model explicitly:
+
+>>> wrapped_model = mgpu.model
+>>> output = wrapped_model(input_tensor)
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+class CudaMultiGPU:
+    """Prepare a model to use all available CUDA GPUs.
+
+    This class detects all CUDA devices on the host machine and, when CUDA is
+    available, wraps the provided :class:`torch.nn.Module` in
+    :class:`torch.nn.DataParallel` so that the model runs in parallel on all
+    GPUs.  If CUDA is not available, the model is left on the CPU.
+
+    Notes
+    -----
+    The :class:`CudaMultiGPU` instance is itself callable and forwards all
+    provided arguments to the wrapped model.  The underlying model can also be
+    accessed through the :attr:`model` attribute if direct access is preferred.
+    """
+
+    def __init__(self, model: torch.nn.Module, verbose: bool = True) -> None:
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+
+        if torch.cuda.is_available():
+            if self.device_count > 1:
+                model = torch.nn.DataParallel(model, device_ids=list(range(self.device_count)))
+            model = model.to(self.device)
+            if verbose:
+                print(f"Using {self.device_count} CUDA device(s).")
+        elif verbose:
+            print("CUDA not available. Running on CPU.")
+
+        self.model = model
+
+    def __call__(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
+
+
+if __name__ == "__main__":  # pragma: no cover - usage demonstration
+    class _ToyModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fc = torch.nn.Linear(4, 2)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(x)
+
+    example_model = _ToyModel()
+    mgpu = CudaMultiGPU(example_model)
+    sample_input = torch.randn(1, 4).to(mgpu.device)
+    print(mgpu(sample_input))

--- a/gpu_utils.py
+++ b/gpu_utils.py
@@ -35,9 +35,10 @@ class CudaMultiGPU:
 
     Notes
     -----
-    The :class:`CudaMultiGPU` instance is itself callable and forwards all
-    provided arguments to the wrapped model.  The underlying model can also be
-    accessed through the :attr:`model` attribute if direct access is preferred.
+    The :class:`CudaMultiGPU` instance is itself callable and forwards both
+    method calls and attribute access to the wrapped model.  The underlying
+    model can also be accessed through the :attr:`model` attribute if direct
+    access is preferred.
     """
 
     def __init__(self, model: torch.nn.Module, verbose: bool = True) -> None:
@@ -57,6 +58,9 @@ class CudaMultiGPU:
 
     def __call__(self, *args, **kwargs):
         return self.model(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self.model, name)
 
 
 if __name__ == "__main__":  # pragma: no cover - usage demonstration

--- a/vit_gpt2_training_v3_mscoco.py
+++ b/vit_gpt2_training_v3_mscoco.py
@@ -52,7 +52,7 @@ gpt2_model = GPT2LMHeadModel.from_pretrained('gpt2', config=config)
 gpt2_model = CudaMultiGPU(gpt2_model)
 DEVICE = gpt2_model.device
 
-optimizer = AdamW(gpt2_model.model.parameters(), lr=5e-5)
+optimizer = AdamW(gpt2_model.parameters(), lr=5e-5)
 
 writer = SummaryWriter(comment=f"______|vit|gpt_2|{dt.name}|")
 

--- a/vit_gpt2_training_v3_mscoco.py
+++ b/vit_gpt2_training_v3_mscoco.py
@@ -18,6 +18,8 @@ from torch.optim import AdamW
 
 import re
 
+from gpu_utils import CudaMultiGPU
+
 torch.manual_seed(3)
 torch.cuda.manual_seed(3)
 torch.cuda.manual_seed_all(3)
@@ -44,13 +46,13 @@ train_loader, val_loader, test_loader = get_loader_and_vocab(dt, tokenizer=gpt2_
 annotation_file = dt.val_captions
 annotation_name = str(annotation_file.parts[-1][:-5])
 coco = COCO(str(annotation_file))
-DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 config = GPT2Config.from_pretrained('gpt2', add_cross_attention=True)
 
 gpt2_model = GPT2LMHeadModel.from_pretrained('gpt2', config=config)
-gpt2_model = gpt2_model.to(DEVICE)
+gpt2_model = CudaMultiGPU(gpt2_model)
+DEVICE = gpt2_model.device
 
-optimizer = AdamW(gpt2_model.parameters(), lr=5e-5)
+optimizer = AdamW(gpt2_model.model.parameters(), lr=5e-5)
 
 writer = SummaryWriter(comment=f"______|vit|gpt_2|{dt.name}|")
 

--- a/vit_gpt2_training_v3_mscoco.py
+++ b/vit_gpt2_training_v3_mscoco.py
@@ -69,8 +69,14 @@ def train_epoch(model, optimizer):
         attention_mask = attention_mask.to(DEVICE)
         input_ids = input_ids.to(DEVICE)
 
-        outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=input_ids, encoder_hidden_states=image_feature)
-        loss = outputs.loss
+        outputs = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            labels=input_ids,
+            encoder_hidden_states=image_feature,
+        )
+        # DataParallel gathers a separate loss from each GPU; average them
+        loss = outputs.loss.mean()
         loss.backward()
         optimizer.step()
         optimizer.zero_grad()

--- a/vit_gpt2_training_v3_vizwiz.py
+++ b/vit_gpt2_training_v3_vizwiz.py
@@ -52,7 +52,7 @@ gpt2_model = GPT2LMHeadModel.from_pretrained('gpt2', config=config)
 gpt2_model = CudaMultiGPU(gpt2_model)
 DEVICE = gpt2_model.device
 
-optimizer = AdamW(gpt2_model.model.parameters(), lr=5e-5)
+optimizer = AdamW(gpt2_model.parameters(), lr=5e-5)
 
 writer = SummaryWriter(comment=f"______|vit|gpt_2|{dt.name}|")
 

--- a/vit_gpt2_training_v3_vizwiz.py
+++ b/vit_gpt2_training_v3_vizwiz.py
@@ -69,8 +69,14 @@ def train_epoch(model, optimizer):
         attention_mask = attention_mask.to(DEVICE)
         input_ids = input_ids.to(DEVICE)
 
-        outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=input_ids, encoder_hidden_states=image_feature)
-        loss = outputs.loss
+        outputs = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            labels=input_ids,
+            encoder_hidden_states=image_feature,
+        )
+        # DataParallel gathers a loss per GPU; average to keep scalar
+        loss = outputs.loss.mean()
         loss.backward()
         optimizer.step()
         optimizer.zero_grad()

--- a/vit_gpt2_training_v3_vizwiz.py
+++ b/vit_gpt2_training_v3_vizwiz.py
@@ -18,6 +18,8 @@ from torch.optim import AdamW
 
 import re
 
+from gpu_utils import CudaMultiGPU
+
 torch.manual_seed(3)
 torch.cuda.manual_seed(3)
 torch.cuda.manual_seed_all(3)
@@ -44,13 +46,13 @@ train_loader, val_loader, test_loader = get_loader_and_vocab(dt, tokenizer=gpt2_
 annotation_file = dt.val_captions
 annotation_name = str(annotation_file.parts[-1][:-5])
 coco = COCO(str(annotation_file))
-DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 config = GPT2Config.from_pretrained('gpt2', add_cross_attention=True)
 
 gpt2_model = GPT2LMHeadModel.from_pretrained('gpt2', config=config)
-gpt2_model = gpt2_model.to(DEVICE)
+gpt2_model = CudaMultiGPU(gpt2_model)
+DEVICE = gpt2_model.device
 
-optimizer = AdamW(gpt2_model.parameters(), lr=5e-5)
+optimizer = AdamW(gpt2_model.model.parameters(), lr=5e-5)
 
 writer = SummaryWriter(comment=f"______|vit|gpt_2|{dt.name}|")
 


### PR DESCRIPTION
## Summary
- Provide a reusable `CudaMultiGPU` class that configures PyTorch models to utilize all available CUDA GPUs via `DataParallel`
- Document usage with inline examples and a runnable demonstration
- Wrap GPT-2 training scripts with `CudaMultiGPU` so they automatically run on all detected GPUs

## Testing
- `python -m py_compile gpu_utils.py vit_gpt2_training_v3_mscoco.py vit_gpt2_training_v3_vizwiz.py`


------
https://chatgpt.com/codex/tasks/task_e_68c304a01e1083279f7c33abb01a1c60